### PR TITLE
Point to index.Rmd rather than index.R

### DIFF
--- a/getting_ready_for_submission/index.Rmd
+++ b/getting_ready_for_submission/index.Rmd
@@ -18,7 +18,7 @@ bibliography: ../refs.bib
 knitr::opts_chunk$set(eval = FALSE)
 ```
 
-All code for this document is located at [here](https://raw.githubusercontent.com/muschellij2/neuroc/master/getting_ready_for_submission/index.R).
+All code for this document is located [here](https://github.com/muschellij2/neuroc/blob/master/getting_ready_for_submission/index.Rmd).
 
 ```{r, eval = TRUE, echo = FALSE}
 # pkg_name = "usethis"


### PR DESCRIPTION
The current link for the "All the code..." is pointed at <https://raw.githubusercontent.com/muschellij2/neuroc/master/getting_ready_for_submission/index.R>. Proposed change to 🔗 to index.Rmd