### PR TITLE
typo in title

### DIFF
--- a/getting_ready_for_submission/index.Rmd
+++ b/getting_ready_for_submission/index.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Preparing Your Package for for Submission"
+title: "Preparing Your R Package for Submission"
 author: "John Muschelli"
 date: "`r Sys.Date()`"
 output: 


### PR DESCRIPTION
typo in title "for for" 
Also added "R". This may be self-explanatory in the context of neuroc, but it is not if you e.g. just look at the bookmark.